### PR TITLE
Disable second check for custom profile on the ZONE

### DIFF
--- a/data/platforms/zotac-zone.toml
+++ b/data/platforms/zotac-zone.toml
@@ -1,0 +1,6 @@
+[performance_profile]
+platform_profile_name = "zotac_zone_platform"
+suggested_default = "balanced"
+
+[tdp_limit]
+method = "zotac_zone_platform"

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -37,6 +37,7 @@ pub(crate) enum DeviceType {
     Unknown,
     SteamDeck,
     LegionGoS,
+    ZotacZone,
 }
 
 #[derive(Display, EnumString, PartialEq, Debug, Copy, Clone, TryFromPrimitive)]
@@ -81,6 +82,7 @@ pub(crate) async fn device_variant() -> Result<(DeviceType, String)> {
         ("LENOVO", "83L3" | "83N6" | "83Q2" | "83Q3", _) => {
             (DeviceType::LegionGoS, product_name.to_string())
         }
+        ("ZOTAC", _, "G0A1W" | "G1A1W") => (DeviceType::ZotacZone, board_name.to_string()),
         ("Valve", _, "Jupiter" | "Galileo") => (DeviceType::SteamDeck, board_name.to_string()),
         _ => (DeviceType::Unknown, String::from("unknown")),
     })
@@ -274,6 +276,21 @@ pub mod test {
         assert_eq!(
             device_variant().await.unwrap(),
             (DeviceType::SteamDeck, String::from("Jupiter"))
+        );
+
+        write(crate::path(SYS_VENDOR_PATH), "ZOTAC\n")
+            .await
+            .expect("write");
+        write(crate::path(BOARD_NAME_PATH), "G0A1W\n")
+            .await
+            .expect("write");
+        assert_eq!(
+            steam_deck_variant().await.unwrap(),
+            SteamDeckVariant::Unknown
+        );
+        assert_eq!(
+            device_variant().await.unwrap(),
+            (DeviceType::ZotacZone, String::from("G0A1W"))
         );
 
         write(crate::path(BOARD_NAME_PATH), "Galileo\n")

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -157,6 +157,7 @@ impl PlatformConfig {
         let platform = match device_type().await? {
             DeviceType::SteamDeck => "jupiter",
             DeviceType::LegionGoS => "legion-go-s",
+            DeviceType::ZotacZone => "zotac-zone",
             _ => return Ok(None),
         };
         let config = read_to_string(format!(

--- a/src/power.rs
+++ b/src/power.rs
@@ -630,17 +630,17 @@ impl TdpLimitManager for ZotacZoneTdpLimitManager {
         Ok(min..=max)
     }
 
-    async fn is_active(&self) -> Result<bool> {
-        let config = platform_config().await?;
-        if let Some(config) = config
-            .as_ref()
-            .and_then(|config| config.performance_profile.as_ref())
-        {
-            Ok(get_platform_profile(&config.platform_profile_name).await? == "custom")
-        } else {
-            Ok(true)
-        }
-    }
+    //async fn is_active(&self) -> Result<bool> {
+    //    let config = platform_config().await?;
+    //    if let Some(config) = config
+    //        .as_ref()
+    //        .and_then(|config| config.performance_profile.as_ref())
+    //    {
+    //        Ok(get_platform_profile(&config.platform_profile_name).await? == "custom")
+    //    } else {
+    //        Ok(true)
+    //    }
+    //}
 }
 
 pub(crate) async fn get_max_charge_level() -> Result<i32> {

--- a/src/power.rs
+++ b/src/power.rs
@@ -94,6 +94,7 @@ pub enum CPUScalingGovernor {
 pub enum TdpLimitingMethod {
     GpuHwmon,
     LenovoWmi,
+    ZotacZonePlatform,
 }
 
 #[derive(Debug)]
@@ -101,6 +102,9 @@ pub(crate) struct GpuHwmonTdpLimitManager {}
 
 #[derive(Debug)]
 pub(crate) struct LenovoWmiTdpLimitManager {}
+
+#[derive(Debug)]
+pub(crate) struct ZotacZoneTdpLimitManager {}
 
 #[async_trait]
 pub(crate) trait TdpLimitManager: Send + Sync {
@@ -122,6 +126,7 @@ pub(crate) async fn tdp_limit_manager() -> Result<Box<dyn TdpLimitManager>> {
     Ok(match config.method {
         TdpLimitingMethod::LenovoWmi => Box::new(LenovoWmiTdpLimitManager {}),
         TdpLimitingMethod::GpuHwmon => Box::new(GpuHwmonTdpLimitManager {}),
+        TdpLimitingMethod::ZotacZonePlatform => Box::new(ZotacZoneTdpLimitManager {}),
     })
 }
 
@@ -479,6 +484,96 @@ impl TdpLimitManager for LenovoWmiTdpLimitManager {
                 "TDP limiting not active"
             );
         }
+        let base = path(Self::PREFIX);
+
+        fs::read_to_string(base.join(Self::SPL_SUFFIX).join("current_value"))
+            .await
+            .map_err(|message| anyhow!("Error reading sysfs: {message}"))?
+            .trim()
+            .parse()
+            .map_err(|e| anyhow!("Error parsing value: {e}"))
+    }
+
+    async fn set_tdp_limit(&self, limit: u32) -> Result<()> {
+        ensure!(
+            self.get_tdp_limit_range().await?.contains(&limit),
+            "Invalid limit"
+        );
+
+        let limit = limit.to_string();
+        let base = path(Self::PREFIX);
+        write_synced(
+            base.join(Self::SPL_SUFFIX).join("current_value"),
+            limit.as_bytes(),
+        )
+        .await
+        .inspect_err(|message| error!("Error writing to sysfs file: {message}"))?;
+        write_synced(
+            base.join(Self::SPPT_SUFFIX).join("current_value"),
+            limit.as_bytes(),
+        )
+        .await
+        .inspect_err(|message| error!("Error writing to sysfs file: {message}"))?;
+        write_synced(
+            base.join(Self::FPPT_SUFFIX).join("current_value"),
+            limit.as_bytes(),
+        )
+        .await
+        .inspect_err(|message| error!("Error writing to sysfs file: {message}"))
+    }
+
+    async fn get_tdp_limit_range(&self) -> Result<RangeInclusive<u32>> {
+        let base = path(Self::PREFIX).join(Self::SPL_SUFFIX);
+
+        let min: u32 = fs::read_to_string(base.join("min_value"))
+            .await
+            .map_err(|message| anyhow!("Error reading sysfs: {message}"))?
+            .trim()
+            .parse()
+            .map_err(|e| anyhow!("Error parsing value: {e}"))?;
+        let max: u32 = fs::read_to_string(base.join("max_value"))
+            .await
+            .map_err(|message| anyhow!("Error reading sysfs: {message}"))?
+            .trim()
+            .parse()
+            .map_err(|e| anyhow!("Error parsing value: {e}"))?;
+        Ok(min..=max)
+    }
+
+    async fn is_active(&self) -> Result<bool> {
+        let config = platform_config().await?;
+        if let Some(config) = config
+            .as_ref()
+            .and_then(|config| config.performance_profile.as_ref())
+        {
+            Ok(get_platform_profile(&config.platform_profile_name).await? == "custom")
+        } else {
+            Ok(true)
+        }
+    }
+}
+
+impl ZotacZoneTdpLimitManager {
+    const PREFIX: &str = "/sys/class/firmware-attributes/zotac_zone_platform/attributes";
+    const SPL_SUFFIX: &str = "ppt_pl1_spl";
+    const SPPT_SUFFIX: &str = "ppt_pl2_sppt";
+    const FPPT_SUFFIX: &str = "ppt_pl3_fppt";
+}
+
+#[async_trait]
+impl TdpLimitManager for ZotacZoneTdpLimitManager {
+    async fn get_tdp_limit(&self) -> Result<u32> {
+        let config = platform_config().await?;
+        // The driver will set platform_profile to custom when TDP is set
+        // if let Some(config) = config
+        //     .as_ref()
+        //     .and_then(|config| config.performance_profile.as_ref())
+        // {
+        //     ensure!(
+        //         get_platform_profile(&config.platform_profile_name).await? == "custom",
+        //         "TDP limiting not active"
+        //     );
+        // }
         let base = path(Self::PREFIX);
 
         fs::read_to_string(base.join(Self::SPL_SUFFIX).join("current_value"))


### PR DESCRIPTION
Second check for the custom profile is needed to be disabled as well. Otherwise TDP max values are not detected by SteamOS Manager when a platform profile other than `custom` was set before.